### PR TITLE
Add Go CI with per-folder tests

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,0 +1,107 @@
+name: Go CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - name: Check formatting
+        run: |
+          UNFORMATTED=$(gofmt -l $(git ls-files '*.go'))
+          if [ -n "$UNFORMATTED" ]; then
+            echo "Files not formatted:" >&2
+            echo "$UNFORMATTED" >&2
+            exit 1
+          fi
+      - name: Run go vet
+        run: go vet ./...
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          args: --timeout 5m
+
+  test_01_goroutines:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - name: Run tests in 01_goroutines
+        run: |
+          cd concurrency_go_tasks/01_goroutines
+          go test ./...
+
+  test_02_channels:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - name: Run tests in 02_channels
+        run: |
+          cd concurrency_go_tasks/02_channels
+          go test ./...
+
+  test_03_composition:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - name: Run tests in 03_composition
+        run: |
+          cd concurrency_go_tasks/03_composition
+          go test ./...
+
+  test_04_time:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - name: Run tests in 04_time
+        run: |
+          cd concurrency_go_tasks/04_time
+          go test ./...
+
+  test_05_context:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - name: Run tests in 05_context
+        run: |
+          cd concurrency_go_tasks/05_context
+          go test ./...
+
+  test_06_sync:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - name: Run tests in 06_sync
+        run: |
+          cd concurrency_go_tasks/06_sync
+          go test ./...


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint Go files and run tests
- run tests for each topic folder in parallel jobs

## Testing
- `gofmt -l $(git ls-files '*.go')`
- `go vet ./...` *(inside module)*
- `go test ./01_goroutines/...` *(fails: expected 10 lines, got 1)*
- `go test ./02_channels/...` *(fails: expected 10 numbers, got 1)*
- `go test ./03_composition/...` *(fails: expected 110, got 0)*
- `go test ./04_time/...` *(fails: panic: runtime error)*
- `go test ./05_context/...` *(fails: ожидалась ошибка отмены)*
- `go test ./06_sync/...` *(fails: expected key to exist)*

------
https://chatgpt.com/codex/tasks/task_e_686b62a80a0c832ba2b270e9c88d423d